### PR TITLE
Remove StandardPromise dependency, bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/http-request",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Simple Node HTTP request builder",
   "main": "src/HttpRequest.js",
   "scripts": {
@@ -22,7 +22,6 @@
   "dependencies": {
     "@unplgtc/cblogger": "0.1.1",
     "@unplgtc/standard-error": "0.1.0",
-    "@unplgtc/standard-promise": "0.2.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5"
   }

--- a/src/HttpRequest.js
+++ b/src/HttpRequest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('@unplgtc/standard-promise');
 const rp = require('request-promise-native');
 const StandardError = require('@unplgtc/standard-error');
 
@@ -57,19 +56,19 @@ const HttpRequest = {
 
 const HttpRequestExecutor = {
 	get(payload = this.payload) {
-		return _(this.execute('get', payload));
+		return this.execute('get', payload);
 	},
 
 	post(payload = this.payload) {
-		return _(this.execute('post', payload));
+		return this.execute('post', payload);
 	},
 
 	put(payload = this.payload) {
-		return _(this.execute('put', payload));
+		return this.execute('put', payload);
 	},
 
 	delete(payload = this.payload) {
-		return _(this.execute('delete', payload));
+		return this.execute('delete', payload);
 	},
 
 	execute(method, payload = this.payload) {

--- a/test/HttpRequest.test.js
+++ b/test/HttpRequest.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('@unplgtc/standard-promise');
 const HttpRequest = require('./../src/HttpRequest');
 const rp = require('request-promise-native');
 const StandardError = require('@unplgtc/standard-error');
@@ -57,14 +56,10 @@ test('Can send a GET request', async() => {
 
 	// Execute
 	var res = await req.get();
-	var res2 = await _(req.get());
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
-	expect(res2.err).toBe(undefined);
-	expect(res2.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can send a POST request', async() => {
@@ -76,14 +71,10 @@ test('Can send a POST request', async() => {
 
 	// Execute
 	var res = await req.post();
-	var res2 = await _(req.post());
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(req.payload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
-	expect(res2.err).toBe(undefined);
-	expect(res2.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can send a PUT request', async() => {
@@ -95,14 +86,10 @@ test('Can send a PUT request', async() => {
 
 	// Execute
 	var res = await req.put();
-	var res2 = await _(req.put());
 
 	// Test
 	expect(rp.put).toHaveBeenCalledWith(req.payload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
-	expect(res2.err).toBe(undefined);
-	expect(res2.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can send a DELETE request', async() => {
@@ -114,14 +101,10 @@ test('Can send a DELETE request', async() => {
 
 	// Execute
 	var res = await req.delete();
-	var res2 = await _(req.delete());
 
 	// Test
 	expect(rp.delete).toHaveBeenCalledWith(req.payload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
-	expect(res2.err).toBe(undefined);
-	expect(res2.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can build and send a request in one line', async() => {
@@ -135,8 +118,7 @@ test('Can build and send a request in one line', async() => {
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('StandardError returned when request is made with empty payload', async() => {
@@ -145,12 +127,14 @@ test('StandardError returned when request is made with empty payload', async() =
 	req.build();
 
 	// Execute
-	var res = await _(req.get());
+	var resErr;
+	var res = await req.get()
+		.catch((err) => { resErr = err });
 
 	// Test
 	expect(rp.get).not.toHaveBeenCalled();
-	expect(res.err).toEqual(StandardError.HttpRequestExecutor_400);
-	expect(res.data).toBe(undefined);
+	expect(resErr).toEqual(StandardError.HttpRequestExecutor_400);
+	expect(res).toBe(undefined);
 });
 
 test('StandardError returned when request is made with empty url', async() => {
@@ -159,15 +143,17 @@ test('StandardError returned when request is made with empty url', async() => {
 	req.build(payloadWithoutUrl);
 
 	// Execute
-	var res = await _(req.get());
+	var resErr;
+	var res = await req.get()
+		.catch((err) => { resErr = err });
 
 	// Test
 	expect(rp.get).not.toHaveBeenCalled();
-	expect(res.err).toEqual(StandardError.HttpRequestExecutor_400);
-	expect(res.data).toBe(undefined);
+	expect(resErr).toEqual(StandardError.HttpRequestExecutor_400);
+	expect(res).toBe(undefined);
 });
 
-test('Can execute a request directly without automatic StandardPromise', async() => {
+test('Can execute a request directly', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
@@ -176,13 +162,10 @@ test('Can execute a request directly without automatic StandardPromise', async()
 
 	// Execute
 	var res = await req.execute('get');
-	var res2 = await _(req.execute('get'));
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
 	expect(res).toBe(simpleMockedResponse);
-	expect(res2.err).toBe(undefined);
-	expect(res2.data).toBe(simpleMockedResponse);
 });
 
 test('Can assemble a request piece by piece', async() => {
@@ -200,8 +183,7 @@ test('Can assemble a request piece by piece', async() => {
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can chain the piece by piece assembly of a request', async() => {
@@ -219,8 +201,7 @@ test('Can chain the piece by piece assembly of a request', async() => {
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });
 
 test('Can chain creation, assembly, and execution of an HttpRequest', async() => {
@@ -237,6 +218,5 @@ test('Can chain creation, assembly, and execution of an HttpRequest', async() =>
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
-	expect(res.err).toBe(undefined);
-	expect(res.data).toBe(simpleMockedResponse);
+	expect(res).toBe(simpleMockedResponse);
 });


### PR DESCRIPTION
Callers can wrap with StandardPromises as they please, but it's unnecessary to force that at the HttpRequest level. Not forcing the StandardPromise return format makes this package far more versatile.