### PR TITLE
Return Full Response by Default and Added Timeout Native Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Builder-style HTTP request executor for Node applications
 
-HttpRequest is a simple Node HTTP client which implments a [fluid interface](https://en.wikipedia.org/wiki/Fluent_interface) to build and send requests. HttpRequest Objects can be built in a number of different ways, including building and sending them imediately or building them over time and sending after all requires pieces have been assembled. HttpRequest encourages thinking of requests as Objects rather than actions: an HttpRequest Object holds its payload internally and can send it at any time — immedaitely or later on. This is a subtle but important distinction from other HTTP clients which expect a completed payload to be passed into a function call for instant execution.
+HttpRequest is a simple Node HTTP client which implements a [fluid interface](https://en.wikipedia.org/wiki/Fluent_interface) to build and send requests. HttpRequest Objects can be built in a number of different ways, including building and sending them immediately or building them over time and sending after all requires pieces have been assembled. HttpRequest encourages thinking of requests as Objects rather than actions: an HttpRequest Object holds its payload internally and can send it at any time — immediately or later on. This is a subtle but important distinction from other HTTP clients which expect a completed payload to be passed into a function call for instant execution.
 
 HttpRequest Objects can be reused to fire the same request multiple time in a row, or to tweak a few request fields for different requests while persisting common values. They can be passed between functions and triggered by any of them without needing a particular function to deal with execution details. The fluid interface allows building HttpRequests with a chained syntax that is clear and concise.
 
@@ -27,7 +27,7 @@ var anotherReq = HttpRequest.create();
 
 `HttpRequest.create()` is just a shortcut for `Object.create(HttpRequest)`, so they can be used entirely interchangeably based on your code style preferences.
 
-HttpRequests currently support six **Native Fields**: `url`, `headers`, `body`, `json`, `qs`, and `resolveWithFullResponse`. All additional fields supported by the [request package](https://www.npmjs.com/package/request) are still supported as **Option Fields**. All fields, both optional and native, can be set with a single payload using the `build()` function.
+HttpRequests currently support seven **Native Fields**: `url`, `headers`, `body`, `json`, `qs`, `timeout`, and `resolveWithFullResponse`. All additional fields supported by the [request package](https://www.npmjs.com/package/request) are still supported as **Option Fields**. All fields, both optional and native, can be set with a single payload using the `build()` function.
 
 ```js
 var req = HttpRequest.create();
@@ -39,6 +39,7 @@ req.build({
 	body: {
 		someKey: 'some_value'
 	},
+	timeout: 5000,
 	json: true
 });
 ```
@@ -54,6 +55,7 @@ Each native field can be set individually, using the specified setter below, or 
 | `body`                    | `setBody()`                    |
 | `json`                    | `setJson()`                    |
 | `qs`                      | `setQs()`                      |
+| `timeout`                 | `setTimeout()`                 |
 | `resolveWithFullResponse` | `setResolveWithFullResponse()` |
 
 ```js
@@ -67,6 +69,7 @@ var req = HttpRequest.create()
 		someKey: 'some_value'
 	})
 	.setJson(true)
+	.setTimeout(3000)
 	.setResolveWithFullResponse(true);
 ```
 
@@ -134,3 +137,12 @@ var req = HttpRequest.create()
 console.log(req.payload);
 // { url: 'some_url' }
 ```
+
+## Further Documentation
+
+Please refer to the [`request-promise` documentation](https://www.npmjs.com/package/request-promise) for further specifications such as the response data format and additional optional fields. Everything with the response and options will be the same except the following:
+
+- This implementation uses [`request-promise-native`](https://www.npmjs.com/package/request-promise-native) that uses native ES6 promises instead of Bluebird promises.
+- Mind that native ES6 promises have fewer features than Bluebird promises do. In particular, the .finally(...) method is not available.
+- `resolveWithFullResponse` is set to `true` by default, meaning the response data is much closer to the [`request` library](https://www.npmjs.com/package/request) format and `statusCode` and `headers` will be included in each response.
+    - Setting `resolveWithFullResponse` to `false` will return only the body of the response once the Promise is resolved. 

--- a/src/HttpRequest.js
+++ b/src/HttpRequest.js
@@ -12,9 +12,10 @@ const HttpRequest = {
 			...(this.body != null    && { body: this.body       }),
 			...(this.json != null    && { json: this.json       }),
 			...(this.qs != null      && { qs: this.qs           }),
-			...(this.resolveWithFullResponse != null && { 
-				resolveWithFullResponse: this.resolveWithFullResponse 
-			})
+			...(this.timeout != null && { timeout: this.timeout }),
+			resolveWithFullResponse: (this.resolveWithFullResponse != null ?
+				this.resolveWithFullResponse : true
+			)
 		}
 	},
 
@@ -23,13 +24,14 @@ const HttpRequest = {
 	},
 
 	build(data = {}) {
-		const {url, headers, body, json, qs, resolveWithFullResponse, ...options} = data;
+		const {url, headers, body, json, qs, resolveWithFullResponse, timeout, ...options} = data;
 
 		url != null     && (this.url = url);
 		headers != null && (this.headers = headers);
 		body != null    && (this.body = body);
 		json != null    && (this.json = json);
 		qs != null      && (this.qs = qs);
+		timeout != null && (this.timeout = timeout);
 		resolveWithFullResponse != null && (this.resolveWithFullResponse = resolveWithFullResponse);
 
 		Object.keys(options).length > 0 && (this.options = options);
@@ -72,6 +74,11 @@ const HttpRequest = {
 
 	setQs(qs) {
 		this.qs = qs;
+		return this;
+	},
+
+	setTimeout(timeout) {
+		this.timeout = timeout;
 		return this;
 	},
 

--- a/test/HttpRequest.test.js
+++ b/test/HttpRequest.test.js
@@ -11,7 +11,8 @@ var simpleGetDeletePayload = {
 	headers: {
 		header1: 'test_header'
 	},
-	json: true
+	json: true,
+	resolveWithFullResponse: true
 }
 
 var simplePutPostPayload = {
@@ -22,7 +23,8 @@ var simplePutPostPayload = {
 	body: {
 		testing: true
 	},
-	json: true
+	json: true,
+	resolveWithFullResponse: true
 }
 
 var payloadWithoutUrl = {
@@ -246,6 +248,43 @@ test('Can send a GET request with a query string', async() => {
 	expect(res).toBe(simpleMockedResponse);
 });
 
+test('Has a proper default payload value for "resolveWithFullResponse"', async() => {
+	// Setup
+	rp.get.mockResolvedValue(simpleMockedResponse);
+	
+	var {resolveWithFullResponse, ...reqPayload} = simpleGetDeletePayload;
+
+	var req = Object.create(HttpRequest);
+	req.build(reqPayload);
+
+	// Execute
+	var res = await req.get();
+
+	// Test
+	expect(req.payload.resolveWithFullResponse).toBe(true);
+	expect(rp.get).toHaveBeenCalledWith(req.payload);
+	expect(res).toBe(simpleMockedResponse);
+});
+
+test('Can send a request with a timeout', async() => {
+	// Setup
+	rp.get.mockResolvedValue(simpleMockedResponse);
+
+	var req = Object.create(HttpRequest);
+	req.build({
+		...simpleGetDeletePayload,
+		timeout: 3000
+	});
+
+	// Execute
+	var res = await req.get();
+
+	// Test
+	expect(req.payload.timeout).toBe(3000);
+	expect(rp.get).toHaveBeenCalledWith(req.payload);
+	expect(res).toBe(simpleMockedResponse);
+});
+
 test('Can send a request with "resolveWithFullResponse" flag', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
@@ -253,14 +292,14 @@ test('Can send a request with "resolveWithFullResponse" flag', async() => {
 	var req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload,
-		resolveWithFullResponse: true
+		resolveWithFullResponse: false
 	});
 
 	// Execute
 	var res = await req.get();
 
 	// Test
-	expect(req.payload.resolveWithFullResponse).toBe(true);
+	expect(req.payload.resolveWithFullResponse).toBe(false);
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
 	expect(res).toBe(simpleMockedResponse);
 });


### PR DESCRIPTION
This update adds the `timeout` option as a Native Field and returns a full response body as a default option by setting `resolveWithFullResponse` to `true` whenever it is not set.

## Changes

- Added `timeout` as a Native Field
- Set `resolveWithFullResponse` to `true` by default
- Updated documentation to reference the `request`, `request-promise` and `request-promise-native` libraries
- Added tests for `timeout` and default `resolveWithFullResponse`