### PR TITLE
Update the HttpRequest interface to use eponymous setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,36 +52,36 @@ req.build({
 
 ### Native Fields
 
-Each native field can be set individually, using the specified setter below, or referenced as a direct child of the HttpRequest object instance.
+Each native field can be set individually using its eponymous setter, and can be referenced from the HttpRequest object's `payload` field. An extra `header()` setter exists to set individual values in the `headers` field.
 
 | Field Name                | Setter                         |
 | ------------------------- | ------------------------------ |
-| `url`                     | `setUrl()`                     |
-| `headers`                 | `setHeaders()`                 |
-| `body`                    | `setBody()`                    |
-| `json`                    | `setJson()`                    |
-| `qs`                      | `setQs()`                      |
-| `timeout`                 | `setTimeout()`                 |
-| `resolveWithFullResponse` | `setResolveWithFullResponse()` |
+| `url`                     | `url()`                        |
+| `headers`                 | `headers()`                    |
+| `body`                    | `body()`                       |
+| `json`                    | `json()`                       |
+| `qs`                      | `qs()`                         |
+| `timeout`                 | `timeout()`                    |
+| `resolveWithFullResponse` | `resolveWithFullResponse()`    |
 
 ```js
 var req = HttpRequest.create()
-	.setUrl('some_url')
-	.setHeaders({
+	.url('some_url')
+	.headers({
 		Authorization: 'some_token'
 	})
-	.setHeader('headerTitle', 'header_value')
-	.setBody({
+	.header('headerTitle', 'header_value')
+	.body({
 		someKey: 'some_value'
 	})
-	.setJson(true)
-	.setTimeout(3000)
-	.setResolveWithFullResponse(true);
+	.json(true)
+	.timeout(3000)
+	.resolveWithFullResponse(false);
 ```
 
 ### Option Fields
 
-All option fields can be set using the `setOptions()` or `setOption()` methods and directly referenced as a child of the `options` field of the HttpRequest object instance.
+All option fields can be set using the `options()` or `option()` functions and referenced as children of the `options` field of the HttpRequest object's `payload`.
 
 ```js
 var req = HttpRequest.create();
@@ -91,17 +91,17 @@ req.build({
 });
 
 // get the optional field's data
-var optionalData = req.options.optionalField;
+var optionalData = req.payload.options.optionalField;
 
 // set an optional field to a new value
-req.setOption('optionalField', 'other_data');
+req.option('optionalField', 'other_data');
 ```
 
-#### setOptions(options)
+#### options(options)
 
 A function that sets all options to the specified payload. Any existing option fields will be overwritten.
 
-#### setOption(key, value)
+#### option(key, value)
 
 The first argument is the name of the option to update. The second argument is the value to store for the specified option.
 
@@ -159,10 +159,10 @@ These can of course be chained along with the other functions to immediately bui
 
 ```js
 var res = HttpRequest.create()
-	.setUrl('some_url')
-	.setHeader('Authorization', 'some_token')
-	.setBody({ someKey: 'some_value' })
-	.setJson(true)
+	.url('some_url')
+	.header('Authorization', 'some_token')
+	.body({ someKey: 'some_value' })
+	.json(true)
 	.post();
 ```
 
@@ -178,7 +178,7 @@ Finally, if you have an existing HttpRequest Object and want to review its paylo
 
 ```js
 var req = HttpRequest.create()
-	.setUrl('some_url');
+	.url('some_url');
 
 console.log(req.payload);
 // { url: 'some_url' }
@@ -188,7 +188,7 @@ console.log(req.payload);
 
 Please refer to the [`request-promise` documentation](https://www.npmjs.com/package/request-promise) for further specifications such as the response data format and additional optional fields. Everything with the response and options will be the same except the following:
 
-- This implementation uses [`request-promise-native`](https://www.npmjs.com/package/request-promise-native) that uses native ES6 promises instead of Bluebird promises.
-- Mind that native ES6 promises have fewer features than Bluebird promises do. In particular, the .finally(...) method is not available.
-- `resolveWithFullResponse` is set to `true` by default, meaning the response data is much closer to the [`request` library](https://www.npmjs.com/package/request) format and `statusCode` and `headers` will be included in each response.
-    - Setting `resolveWithFullResponse` to `false` will return only the body of the response once the Promise is resolved. 
+- This implementation uses [`request-promise-native`](https://www.npmjs.com/package/request-promise-native), which itself uses native ES6 promises instead of Bluebird promises.
+- Mind that native ES6 promises have fewer features than Bluebird promises do. In particular, the `.finally(...)` method is not available.
+- In this implementation `resolveWithFullResponse` is set to `true` by default, meaning the response data is equivalent to the [`request` library](https://www.npmjs.com/package/request) format and `statusCode` and `headers` will be included in each response. Unsuccessful status codes will still reject.
+    - Setting `resolveWithFullResponse` to `false` will return only the body of the response once the Promise is resolved successfully, which is the default setting of the [`request-promise-native` library](https://www.npmjs.com/package/request-promise-native)

--- a/src/HttpRequest.js
+++ b/src/HttpRequest.js
@@ -6,15 +6,15 @@ const StandardError = require('@unplgtc/standard-error');
 const HttpRequest = {
 	get payload() {
 		return {
-			...(this.options != null && this.options),
-			...(this.url != null     && { url: this.url         }),
-			...(this.headers != null && { headers: this.headers }),
-			...(this.body != null    && { body: this.body       }),
-			...(this.json != null    && { json: this.json       }),
-			...(this.qs != null      && { qs: this.qs           }),
-			...(this.timeout != null && { timeout: this.timeout }),
-			resolveWithFullResponse: (this.resolveWithFullResponse != null ?
-				this.resolveWithFullResponse : true
+			...(this._options != null && this._options),
+			...(this._url != null     && { url: this._url         }),
+			...(this._headers != null && { headers: this._headers }),
+			...(this._body != null    && { body: this._body       }),
+			...(this._json != null    && { json: this._json       }),
+			...(this._qs != null      && { qs: this._qs           }),
+			...(this._timeout != null && { timeout: this._timeout }),
+			resolveWithFullResponse: (this._resolveWithFullResponse != null ?
+				this._resolveWithFullResponse : true
 			)
 		}
 	},
@@ -26,70 +26,72 @@ const HttpRequest = {
 	build(data = {}) {
 		const {url, headers, body, json, qs, resolveWithFullResponse, timeout, ...options} = data;
 
-		url != null     && (this.url = url);
-		headers != null && (this.headers = headers);
-		body != null    && (this.body = body);
-		json != null    && (this.json = json);
-		qs != null      && (this.qs = qs);
-		timeout != null && (this.timeout = timeout);
-		resolveWithFullResponse != null && (this.resolveWithFullResponse = resolveWithFullResponse);
+		url != null     && (this._url = url);
+		headers != null && (this._headers = headers);
+		body != null    && (this._body = body);
+		json != null    && (this._json = json);
+		qs != null      && (this._qs = qs);
+		timeout != null && (this._timeout = timeout);
+		resolveWithFullResponse != null && (this._resolveWithFullResponse = resolveWithFullResponse);
 
-		Object.keys(options).length > 0 && (this.options = options);
+		Object.keys(options).length > 0 && (this._options = options);
 
 		return this;
 	},
 
-	setUrl(url) {
-		this.url = url;
+	url(url) {
+		this._url = url;
 		return this;
 	},
 
-	setHeader(key, value) {
-		if (!this.headers) {
-			this.headers = {};
+	header(key, value) {
+		if (!this._headers) {
+			this._headers = {};
 		}
-		this.headers[key] = value;
+		this._headers[key] = value;
 		return this;
 	},
 
-	setHeaders(headers) {
-		this.headers = headers;
+	headers(headers) {
+		this._headers = Object.assign(headers, this._headers);
 		return this;
 	},
 
-	setBody(body) {
-		this.body = body;
+	body(body) {
+		this._body = body;
 		return this;
 	},
 
-	setJson(json) {
-		this.json = json;
+	json(json) {
+		// If nothing is passed to this function, set _json to true
+		this._json = json != null ? json : true;
 		return this;
 	},
 
-	setResolveWithFullResponse(resolveWithFullResponse) {
-		this.resolveWithFullResponse = resolveWithFullResponse;
+	resolveWithFullResponse(resolveWithFullResponse) {
+		// If nothing is passed to this function, set _resolveWithFullResponse to true
+		this._resolveWithFullResponse = resolveWithFullResponse != null ? resolveWithFullResponse : true;
 		return this;
 	},
 
-	setQs(qs) {
-		this.qs = qs;
+	qs(qs) {
+		this._qs = qs;
 		return this;
 	},
 
-	setTimeout(timeout) {
-		this.timeout = timeout;
+	timeout(timeout) {
+		this._timeout = timeout;
 		return this;
 	},
 
-	setOption(key, value) {
+	option(key, value) {
 		return this.build({
-			...(this.options != null && this.options), 
+			...(this._options != null && this._options), 
 			[key]: value 
 		});
 	},
 
-	setOptions(options) {
+	options(options) {
 		this.options = {};
 		// set native fields first, then options
 		return this.build(options);

--- a/test/HttpRequest.test.js
+++ b/test/HttpRequest.test.js
@@ -175,10 +175,10 @@ test('Can assemble a request piece by piece', async() => {
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
 	var req = Object.create(HttpRequest);
-	req.setUrl(simplePutPostPayload.url);
-	req.setHeaders(simplePutPostPayload.headers);
-	req.setBody(simplePutPostPayload.body);
-	req.setJson(simplePutPostPayload.json);
+	req.url(simplePutPostPayload.url);
+	req.headers(simplePutPostPayload.headers);
+	req.body(simplePutPostPayload.body);
+	req.json(simplePutPostPayload.json);
 
 	// Execute
 	var res = await req.post();
@@ -193,10 +193,29 @@ test('Can chain the piece by piece assembly of a request', async() => {
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
 	var req = Object.create(HttpRequest);
-	req.setUrl(simplePutPostPayload.url)
-	   .setHeader('header1', simplePutPostPayload.headers.header1)
-	   .setBody(simplePutPostPayload.body)
-	   .setJson(simplePutPostPayload.json);
+	req.url(simplePutPostPayload.url)
+	   .header('header1', simplePutPostPayload.headers.header1)
+	   .body(simplePutPostPayload.body)
+	   .json(simplePutPostPayload.json);
+
+	// Execute
+	var res = await req.post();
+
+	// Test
+	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
+	expect(res).toBe(simpleMockedResponse);
+});
+
+test('resolveWithFullResponse and json can be set to true by not passing values', async() => {
+	// Setup
+	rp.post.mockResolvedValue(simpleMockedResponse);
+
+	var req = Object.create(HttpRequest);
+	req.url(simplePutPostPayload.url)
+	   .header('header1', simplePutPostPayload.headers.header1)
+	   .body(simplePutPostPayload.body)
+	   .resolveWithFullResponse()
+	   .json();
 
 	// Execute
 	var res = await req.post();
@@ -212,10 +231,10 @@ test('Can chain creation, assembly, and execution of an HttpRequest', async() =>
 
 	// Execute
 	var res = await HttpRequest.create()
-	                           .setUrl(simplePutPostPayload.url)
-	                           .setHeaders(simplePutPostPayload.headers)
-	                           .setBody(simplePutPostPayload.body)
-	                           .setJson(simplePutPostPayload.json)
+	                           .url(simplePutPostPayload.url)
+	                           .headers(simplePutPostPayload.headers)
+	                           .body(simplePutPostPayload.body)
+	                           .json(simplePutPostPayload.json)
 	                           .post();
 
 	// Test
@@ -333,7 +352,7 @@ test('Can edit a POST request optional parameter after creation', async() => {
 		myTestOption: 1234
 	});
 	
-	req.setOption('myTestOption', 4321);
+	req.option('myTestOption', 4321);
 
 	// Execute
 	var res = await req.post();


### PR DESCRIPTION
 For example, use `field()` to set the `field` property rather than `setField()`

I think this interface is cleaner and nicer to use. The only downside is losing the ability to reference fields directly from the HttpRequest object, but you can still reference them from `HttpRequest.payload` which I think is a fine compromise since introspection on a pending HttpRequest is going to be a very rare task whereas setting values is a core aspect of usage.

/cc @trevorrecker 