### PR TITLE
Add support for batched requests

### DIFF
--- a/src/BatchRequest.js
+++ b/src/BatchRequest.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const HttpRequestBase = require('./HttpRequestBase'),
+      rp = require('request-promise-native'),
+      StandardError = require('@unplgtc/standard-error');
+
+let executionTimer;
+
+const BatchRequest = {
+	requests: [], // How do we clean these once they've executed?
+
+	stallMs: 50,
+	
+	stall(milliseconds) {
+		this.parent
+		? (this.parent.stallMs = milliseconds)
+		: (this.stallMs = milliseconds);
+
+		return this;
+	},
+
+	throttle(milliseconds) {
+		this.parent
+		? (this.parent.throttleMs = milliseconds)
+		: (this.throttleMs = milliseconds);
+
+		return this;
+	},
+
+	addRequest(cleanup) {
+		const child = this.spawnChild();
+		child.result = new Promise((resolve, reject) => {
+			child.resolve = resolve;
+			child.reject = reject;
+		});
+
+		this.requests.push(child);
+		this.cleanup = cleanup;
+
+		return child;
+	},
+
+	spawnChild() {
+		return Object.create(this)
+			.setParent(this);
+	},
+
+	setParent(parent) {
+		Object.defineProperty(this, 'parent', {
+			value: parent,
+			writable: false,
+			configurable: false,
+			enumerable: false
+		});
+
+		return this;
+	},
+
+	set executionTimer(executor) {
+		executionTimer && clearTimeout(executionTimer);
+
+		executor && (executionTimer = setTimeout(executor, this.stallMs));
+	},
+
+	get(shouldExecute) {
+		return shouldExecute
+		? this.execute('get')
+		: this.executeDelayed('get');
+	},
+
+	post(shouldExecute) {
+		return shouldExecute
+		? this.execute('post')
+		: this.executeDelayed('post');
+	},
+
+	put(shouldExecute) {
+		return shouldExecute
+		? this.execute('put')
+		: this.executeDelayed('put');
+	},
+
+	delete(shouldExecute) {
+		return shouldExecute
+		? this.execute('delete')
+		: this.executeDelayed('delete');
+	},
+
+	execute(method) {
+		if (this.parent) {
+			this.method = method;
+			this.parent.clearExecutionTimer();
+			this.parent.executeAll(this.parent.requests)();
+		}
+
+		return this.result;
+	},
+
+	executeDelayed(method) {
+		if (this.parent) {
+			this.method = method;
+			this.parent.setExecutionTimer();
+		}
+
+		return this.result;
+	},
+
+	setExecutionTimer() {
+		this.executionTimer = this.executeAll(this.requests);
+	},
+
+	clearExecutionTimer() {
+		this.executionTimer = undefined;
+	},
+
+	executeAll(requests) {
+		return async () => {
+			this.throttle && this.throttle < 10
+			? await this.executeConcurrently(requests)
+			: await this.executeThrottled(requests);
+
+			this.cleanup();
+		}
+	},
+
+	executeConcurrently(requests) {
+		return Promise.all(
+			requests.map(request => this.executeOne(request))
+		);
+	},
+
+	executeThrottled: async function(requests) {
+		for (const request of requests) {
+			await (this.throttledRequest(request));
+		}
+	},
+
+	throttledRequest(request) {
+		return new Promise((resolve) => {
+			return setTimeout(() => {
+				resolve(this.executeOne(request));
+			}, this.throttleMs);
+		});
+	},
+
+	executeOne: async function(request) {
+		if (!Object.keys(request.payload).length || !request.payload.url || !request.method) {
+			return request.reject(StandardError.BatchRequest_400());
+		}
+		return request.resolve(
+			request.validator
+			? request.validator(await rp[request.method](request.payload))
+			: rp[request.method](request.payload)
+		);
+	}
+}
+
+StandardError.add([
+	{code: 'BatchRequest_400', domain: 'HttpRequest', title: 'Bad Request', message: 'Cannot execute batched HttpRequest with empty payload, url, or method'}
+]);
+
+// Delegate BatchRequest -> HttpRequestBase
+Object.setPrototypeOf(BatchRequest, HttpRequestBase);
+
+module.exports = BatchRequest;

--- a/src/HttpRequest.js
+++ b/src/HttpRequest.js
@@ -1,114 +1,34 @@
 'use strict';
 
-const rp = require('request-promise-native');
-const StandardError = require('@unplgtc/standard-error');
+const BatchRequest = require('./BatchRequest'),
+      HttpRequestBase = require('./HttpRequestBase'),
+      rp = require('request-promise-native'),
+      StandardError = require('@unplgtc/standard-error');
+
+const batchRequests = {};
 
 const HttpRequest = {
-	get payload() {
-		return {
-			...(this._options != null && this._options),
-			...(this._url != null     && { url: this._url         }),
-			...(this._headers != null && { headers: this._headers }),
-			...(this._body != null    && { body: this._body       }),
-			...(this._json != null    && { json: this._json       }),
-			...(this._qs != null      && { qs: this._qs           }),
-			...(this._timeout != null && { timeout: this._timeout }),
-			resolveWithFullResponse: (this._resolveWithFullResponse != null ?
-				this._resolveWithFullResponse : false
-			)
-		}
+	get batchRequests() {
+		return batchRequests;
 	},
 
 	create() {
 		return Object.create(this);
 	},
 
-	build(data = {}) {
-		const {url, headers, body, json, qs, resolveWithFullResponse, timeout, ...options} = data;
+	batch(id) {
+		const batchRequest = batchRequests[id] ||
+			(batchRequests[id] = Object.create(BatchRequest));
 
-		url != null     && (this._url = url);
-		headers != null && (this._headers = headers);
-		body != null    && (this._body = body);
-		json != null    && (this._json = json);
-		qs != null      && (this._qs = qs);
-		timeout != null && (this._timeout = timeout);
-		resolveWithFullResponse != null && (this._resolveWithFullResponse = resolveWithFullResponse);
-
-		Object.keys(options).length > 0 && (this._options = options);
-
-		return this;
+		return batchRequest.addRequest(this.batchCleaner(id));
 	},
 
-	url(url) {
-		this._url = url;
-		return this;
-	},
-
-	header(key, value) {
-		if (!this._headers) {
-			this._headers = {};
+	batchCleaner(id) {
+		return () => {
+			delete batchRequests[id];
 		}
-		this._headers[key] = value;
-		return this;
 	},
 
-	headers(headers) {
-		this._headers = Object.assign(headers, this._headers);
-		return this;
-	},
-
-	body(body) {
-		this._body = body;
-		return this;
-	},
-
-	json(json) {
-		// If nothing is passed to this function, set _json to true
-		this._json = json != null ? json : true;
-		return this;
-	},
-
-	resolveWithFullResponse(resolveWithFullResponse) {
-		// If nothing is passed to this function, set _resolveWithFullResponse to true
-		this._resolveWithFullResponse = resolveWithFullResponse != null ? resolveWithFullResponse : true;
-		return this;
-	},
-
-	qs(qs) {
-		this._qs = qs;
-		return this;
-	},
-
-	timeout(timeout) {
-		this._timeout = timeout;
-		return this;
-	},
-
-	option(key, value) {
-		return this.build({
-			...(this._options != null && this._options), 
-			[key]: value 
-		});
-	},
-
-	options(options) {
-		this.options = {};
-		// set native fields first, then options
-		return this.build(options);
-	},
-
-	validate(validator) {
-		Object.defineProperty(this, 'validator', {
-			value: validator,
-			writable: false,
-			configurable: false,
-			enumerable: false
-		});
-		return this;
-	}
-}
-
-const HttpRequestExecutor = {
 	get(payload = this.payload) {
 		return this.execute('get', payload);
 	},
@@ -127,7 +47,7 @@ const HttpRequestExecutor = {
 
 	execute: async function(method, payload = this.payload) {
 		if (!Object.keys(payload).length || !payload.url) {
-			return Promise.reject(StandardError.HttpRequestExecutor_400());
+			return Promise.reject(StandardError.HttpRequest_400());
 		}
 		return this.validator
 		       ? this.validator(await rp[method](payload))
@@ -136,10 +56,10 @@ const HttpRequestExecutor = {
 }
 
 StandardError.add([
-	{code: 'HttpRequestExecutor_400', domain: 'HttpRequest', title: 'Bad Request', message: 'Cannot execute HttpRequest with empty payload or url'}
+	{code: 'HttpRequest_400', domain: 'HttpRequest', title: 'Bad Request', message: 'Cannot execute HttpRequest with empty payload or url'}
 ]);
 
-// Delegate from HttpRequest to HttpRequestExecutor
-Object.setPrototypeOf(HttpRequest, HttpRequestExecutor);
+// Delegate HttpRequest -> HttpRequestBase
+Object.setPrototypeOf(HttpRequest, HttpRequestBase);
 
 module.exports = HttpRequest;

--- a/src/HttpRequestBase.js
+++ b/src/HttpRequestBase.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const HttpRequestBase = {
+	get payload() {
+		return {
+			...(this._options != null && this._options),
+			...(this._url != null     && { url: this._url         }),
+			...(this._headers != null && { headers: this._headers }),
+			...(this._body != null    && { body: this._body       }),
+			...(this._json != null    && { json: this._json       }),
+			...(this._qs != null      && { qs: this._qs           }),
+			...(this._timeout != null && { timeout: this._timeout }),
+			resolveWithFullResponse: (this._resolveWithFullResponse != null ?
+				this._resolveWithFullResponse : false
+			)
+		}
+	},
+
+	build(data = {}) {
+		const {url, headers, body, json, qs, resolveWithFullResponse, timeout, ...options} = data;
+
+		url != null     && (this._url = url);
+		headers != null && (this._headers = headers);
+		body != null    && (this._body = body);
+		json != null    && (this._json = json);
+		qs != null      && (this._qs = qs);
+		timeout != null && (this._timeout = timeout);
+		resolveWithFullResponse != null && (this._resolveWithFullResponse = resolveWithFullResponse);
+
+		Object.keys(options).length > 0 && (this._options = options);
+
+		return this;
+	},
+
+	url(url) {
+		this._url = url;
+		return this;
+	},
+
+	header(key, value) {
+		if (!this._headers) {
+			this._headers = {};
+		}
+		this._headers[key] = value;
+		return this;
+	},
+
+	headers(headers) {
+		this._headers = Object.assign(headers, this._headers);
+		return this;
+	},
+
+	body(body) {
+		this._body = body;
+		return this;
+	},
+
+	json(json) {
+		// If nothing is passed to this function, set _json to true
+		this._json = json != null ? json : true;
+		return this;
+	},
+
+	resolveWithFullResponse(resolveWithFullResponse) {
+		// If nothing is passed to this function, set _resolveWithFullResponse to true
+		this._resolveWithFullResponse = resolveWithFullResponse != null ? resolveWithFullResponse : true;
+		return this;
+	},
+
+	qs(qs) {
+		this._qs = qs;
+		return this;
+	},
+
+	timeout(timeout) {
+		this._timeout = timeout;
+		return this;
+	},
+
+	option(key, value) {
+		return this.build({
+			...(this._options != null && this._options), 
+			[key]: value 
+		});
+	},
+
+	options(options) {
+		this.options = {};
+		// set native fields first, then options
+		return this.build(options);
+	},
+
+	validate(validator) {
+		Object.defineProperty(this, 'validator', {
+			value: validator,
+			writable: false,
+			configurable: false,
+			enumerable: false
+		});
+		return this;
+	}
+}
+
+module.exports = HttpRequestBase;

--- a/test/BatchRequest.spec.js
+++ b/test/BatchRequest.spec.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const HttpRequest = require('./../src/HttpRequest');
+const rp = require('request-promise-native');
+const StandardError = require('@unplgtc/standard-error');
+
+jest.mock('request-promise-native');
+
+const simpleGetDeletePayload = {
+	url: 'test_url',
+	headers: {
+		header1: 'test_header'
+	},
+	json: true,
+	resolveWithFullResponse: false
+}
+
+const simplePutPostPayload = {
+	url: 'test_url',
+	headers: {
+		header1: 'test_header'
+	},
+	body: {
+		testing: true
+	},
+	json: true,
+	resolveWithFullResponse: false
+}
+
+const simpleMockedResponse = {
+	testing: true
+}
+
+const simpleMockedResponse2 = {
+	testing2: true
+}
+
+test('Can create and execute a batch request with one request', async() => {
+	// Setup
+	const id = 'id_1';
+	rp.post.mockResolvedValue(simpleMockedResponse);
+
+	const req = HttpRequest.batch(id)
+		.url(simplePutPostPayload.url)
+		.header('header1', simplePutPostPayload.headers.header1)
+		.body(simplePutPostPayload.body)
+		.json(simplePutPostPayload.json);
+
+	// Execute
+	const res = await req.post();
+
+	// Test
+	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
+	expect(res).toBe(simpleMockedResponse);
+});
+
+test('Can create and execute a batch request with multiple requests', async() => {
+	// Setup
+	const id = 'id_2';
+	rp.get.mockResolvedValue(simpleMockedResponse);
+	rp.post.mockResolvedValue(simpleMockedResponse2);
+
+	const req1 = HttpRequest.batch(id)
+		.url(simpleGetDeletePayload.url)
+		.header('header1', simpleGetDeletePayload.headers.header1)
+		.json(simpleGetDeletePayload.json)
+		.get();
+
+	const req2 = HttpRequest.batch(id)
+		.url(simplePutPostPayload.url)
+		.header('header1', simplePutPostPayload.headers.header1)
+		.body(simplePutPostPayload.body)
+		.json(simplePutPostPayload.json)
+		.post();
+
+	// Execute
+	const res1 = await req1;
+	const res2 = await req2;
+
+	// Test
+	expect(rp.get).toHaveBeenCalledWith(simpleGetDeletePayload);
+	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
+	expect(res1).toBe(simpleMockedResponse);
+	expect(res2).toBe(simpleMockedResponse2);
+});
+
+test('Can create and execute a batch request with throttled requests', async() => {
+	// Setup
+	const id = 'id_3';
+	rp.get.mockResolvedValue(simpleMockedResponse);
+	rp.post.mockResolvedValue(simpleMockedResponse2);
+
+	// Test
+	expect(HttpRequest.batchRequests[id]).toBe(undefined);
+
+	// Setup
+	const req1 = HttpRequest.batch(id)
+		.throttle(50)
+		.url(simpleGetDeletePayload.url)
+		.header('header1', simpleGetDeletePayload.headers.header1)
+		.json(simpleGetDeletePayload.json)
+		.get();
+
+	const req2 = HttpRequest.batch(id)
+		.throttle(50)
+		.url(simplePutPostPayload.url)
+		.header('header1', simplePutPostPayload.headers.header1)
+		.body(simplePutPostPayload.body)
+		.json(simplePutPostPayload.json)
+		.post();
+
+	// Test
+	expect(HttpRequest.batchRequests[id]).not.toBe(undefined);
+
+	// Execute
+	const res1 = await req1;
+	const res2 = await req2;
+
+	// Test
+	expect(rp.get).toHaveBeenCalledWith(simpleGetDeletePayload);
+	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
+	expect(res1).toBe(simpleMockedResponse);
+	expect(res2).toBe(simpleMockedResponse2);
+
+	// Delay by one clock cycle to allow HttpRequest to clean up the executed batch
+	await new Promise((resolve, reject) => {
+		setTimeout(() => { resolve() }, 1);
+	});
+	expect(HttpRequest.batchRequests[id]).toBe(undefined);
+});
+
+test('StandardError returned when batch request is made without method', async() => {
+	// Setup
+	const id = 'id_4';
+	rp.get.mockResolvedValue(simpleMockedResponse);
+	rp.post.mockResolvedValue(simpleMockedResponse2);
+
+	const req1 = HttpRequest.batch(id)
+		.url(simpleGetDeletePayload.url)
+		.header('header1', simpleGetDeletePayload.headers.header1)
+		.json(simpleGetDeletePayload.json)
+		.get();
+
+	const req2 = HttpRequest.batch(id)
+		.url(simplePutPostPayload.url)
+		.header('header1', simplePutPostPayload.headers.header1)
+		.body(simplePutPostPayload.body)
+		.json(simplePutPostPayload.json)
+
+	// Execute
+	const res1 = await req1;
+
+	let resErr;
+	const res2 = await req2.result
+		.catch((err) => { resErr = err });
+
+	// Test
+	expect(rp.get).toHaveBeenCalledWith(simpleGetDeletePayload);
+	expect(res1).toBe(simpleMockedResponse);
+	expect(resErr).toEqual(StandardError.BatchRequest_400());
+	expect(res2).toBe(undefined);
+});
+
+test('StandardError returned when batch request is made without url', async() => {
+	// Setup
+	const id = 'id_5';
+
+	const req = HttpRequest.batch(id).get();
+
+	// Execute
+	let resErr;
+	const res = await req
+		.catch((err) => { resErr = err });
+
+	// Test
+	expect(resErr).toEqual(StandardError.BatchRequest_400());
+	expect(res).toBe(undefined);
+});
+
+test('Can immediately execute a batch request', async() => {
+	// Setup
+	const id = 'id_6';
+	rp.get.mockResolvedValue(simpleMockedResponse);
+	rp.post.mockResolvedValue(simpleMockedResponse2);
+
+	const req1 = HttpRequest.batch(id)
+		.url(simpleGetDeletePayload.url)
+		.header('header1', simpleGetDeletePayload.headers.header1)
+		.json(simpleGetDeletePayload.json)
+		.get();
+
+	const req2 = HttpRequest.batch(id)
+		.url(simplePutPostPayload.url)
+		.header('header1', simplePutPostPayload.headers.header1)
+		.body(simplePutPostPayload.body)
+		.json(simplePutPostPayload.json)
+		.post(true);
+
+	// Execute
+	const res1 = await req1;
+	const res2 = await req2;
+
+	// Test
+	expect(rp.get).toHaveBeenCalledWith(simpleGetDeletePayload);
+	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
+	expect(res1).toBe(simpleMockedResponse);
+	expect(res2).toBe(simpleMockedResponse2);
+});

--- a/test/HttpRequest.spec.js
+++ b/test/HttpRequest.spec.js
@@ -6,16 +6,16 @@ const StandardError = require('@unplgtc/standard-error');
 
 jest.mock('request-promise-native');
 
-var simpleGetDeletePayload = {
+const simpleGetDeletePayload = {
 	url: 'test_url',
 	headers: {
 		header1: 'test_header'
 	},
 	json: true,
 	resolveWithFullResponse: false
-}
+};
 
-var simplePutPostPayload = {
+const simplePutPostPayload = {
 	url: 'test_url',
 	headers: {
 		header1: 'test_header'
@@ -25,9 +25,9 @@ var simplePutPostPayload = {
 	},
 	json: true,
 	resolveWithFullResponse: false
-}
+};
 
-var resolveWithFullResponsePutPostPayload = {
+const resolveWithFullResponsePutPostPayload = {
 	url: 'test_url',
 	headers: {
 		header1: 'test_header'
@@ -37,24 +37,24 @@ var resolveWithFullResponsePutPostPayload = {
 	},
 	json: true,
 	resolveWithFullResponse: true
-}
+};
 
-var payloadWithoutUrl = {
+const payloadWithoutUrl = {
 	headers: {
 		header1: 'test_header'
 	},
 	json: true
-}
+};
 
-var simpleMockedResponse = {
+const simpleMockedResponse = {
 	testing: true
-}
+};
 
 test('Can access the payload', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simpleGetDeletePayload);
 
 	// Test
@@ -65,11 +65,11 @@ test('Can send a GET request', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simpleGetDeletePayload);
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
@@ -80,11 +80,11 @@ test('Can send a POST request', async() => {
 	// Setup
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simplePutPostPayload);
 
 	// Execute
-	var res = await req.post();
+	const res = await req.post();
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(req.payload);
@@ -95,11 +95,11 @@ test('Can send a PUT request', async() => {
 	// Setup
 	rp.put.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simplePutPostPayload);
 
 	// Execute
-	var res = await req.put();
+	const res = await req.put();
 
 	// Test
 	expect(rp.put).toHaveBeenCalledWith(req.payload);
@@ -110,11 +110,11 @@ test('Can send a DELETE request', async() => {
 	// Setup
 	rp.delete.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simpleGetDeletePayload);
 
 	// Execute
-	var res = await req.delete();
+	const res = await req.delete();
 
 	// Test
 	expect(rp.delete).toHaveBeenCalledWith(req.payload);
@@ -125,10 +125,10 @@ test('Can build and send a request in one line', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 
 	// Execute
-	var res = await req.build(simpleGetDeletePayload).get();
+	const res = await req.build(simpleGetDeletePayload).get();
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
@@ -137,33 +137,33 @@ test('Can build and send a request in one line', async() => {
 
 test('StandardError returned when request is made with empty payload', async() => {
 	// Setup
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build();
 
 	// Execute
-	var resErr;
-	var res = await req.get()
+	let resErr;
+	const res = await req.get()
 		.catch((err) => { resErr = err });
 
 	// Test
 	expect(rp.get).not.toHaveBeenCalled();
-	expect(resErr).toEqual(StandardError.HttpRequestExecutor_400());
+	expect(resErr).toEqual(StandardError.HttpRequest_400());
 	expect(res).toBe(undefined);
 });
 
 test('StandardError returned when request is made with empty url', async() => {
 	// Setup
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(payloadWithoutUrl);
 
 	// Execute
-	var resErr;
-	var res = await req.get()
+	let resErr;
+	const res = await req.get()
 		.catch((err) => { resErr = err });
 
 	// Test
 	expect(rp.get).not.toHaveBeenCalled();
-	expect(resErr).toEqual(StandardError.HttpRequestExecutor_400());
+	expect(resErr).toEqual(StandardError.HttpRequest_400());
 	expect(res).toBe(undefined);
 });
 
@@ -171,11 +171,11 @@ test('Can execute a request directly', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(simpleGetDeletePayload);
 
 	// Execute
-	var res = await req.execute('get');
+	const res = await req.execute('get');
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);
@@ -186,14 +186,14 @@ test('Can assemble a request piece by piece', async() => {
 	// Setup
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.url(simplePutPostPayload.url);
 	req.headers(simplePutPostPayload.headers);
 	req.body(simplePutPostPayload.body);
 	req.json(simplePutPostPayload.json);
 
 	// Execute
-	var res = await req.post();
+	const res = await req.post();
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
@@ -204,14 +204,14 @@ test('Can chain the piece by piece assembly of a request', async() => {
 	// Setup
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.url(simplePutPostPayload.url)
 	   .header('header1', simplePutPostPayload.headers.header1)
 	   .body(simplePutPostPayload.body)
 	   .json(simplePutPostPayload.json);
 
 	// Execute
-	var res = await req.post();
+	const res = await req.post();
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(simplePutPostPayload);
@@ -222,7 +222,7 @@ test('resolveWithFullResponse and json can be set to true by not passing values'
 	// Setup
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.url(simplePutPostPayload.url)
 	   .header('header1', simplePutPostPayload.headers.header1)
 	   .body(simplePutPostPayload.body)
@@ -230,7 +230,7 @@ test('resolveWithFullResponse and json can be set to true by not passing values'
 	   .json();
 
 	// Execute
-	var res = await req.post();
+	const res = await req.post();
 
 	// Test
 	expect(rp.post).toHaveBeenCalledWith(resolveWithFullResponsePutPostPayload);
@@ -242,7 +242,7 @@ test('Can chain creation, assembly, and execution of an HttpRequest', async() =>
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
 	// Execute
-	var res = await HttpRequest.create()
+	const res = await HttpRequest.create()
 	                           .url(simplePutPostPayload.url)
 	                           .headers(simplePutPostPayload.headers)
 	                           .body(simplePutPostPayload.body)
@@ -258,7 +258,7 @@ test('Can send a GET request with a query string', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload,
 		qs: {
@@ -268,7 +268,7 @@ test('Can send a GET request with a query string', async() => {
 	});
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(req.payload.qs).toEqual({
@@ -283,13 +283,13 @@ test('Has a proper default payload value for "resolveWithFullResponse"', async()
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 	
-	var {resolveWithFullResponse, ...reqPayload} = simpleGetDeletePayload;
+	const {resolveWithFullResponse, ...reqPayload} = simpleGetDeletePayload;
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build(reqPayload);
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(req.payload.resolveWithFullResponse).toBe(false);
@@ -301,14 +301,14 @@ test('Can send a request with a timeout', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload,
 		timeout: 3000
 	});
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(req.payload.timeout).toBe(3000);
@@ -320,14 +320,14 @@ test('Can send a request with "resolveWithFullResponse" flag', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload,
 		resolveWithFullResponse: false
 	});
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(req.payload.resolveWithFullResponse).toBe(false);
@@ -339,14 +339,14 @@ test('Can send a GET request with additional option arguments', async() => {
 	// Setup
 	rp.get.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload,
 		someTestingOption: true
 	});
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(req.payload.someTestingOption).toBe(true);
@@ -358,7 +358,7 @@ test('Can edit a POST request optional parameter after creation', async() => {
 	// Setup
 	rp.post.mockResolvedValue(simpleMockedResponse);
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simplePutPostPayload,
 		myTestOption: 1234
@@ -367,7 +367,7 @@ test('Can edit a POST request optional parameter after creation', async() => {
 	req.option('myTestOption', 4321);
 
 	// Execute
-	var res = await req.post();
+	const res = await req.post();
 
 	// Test
 	expect(req.payload.myTestOption).toBe(4321);
@@ -386,14 +386,14 @@ test('Will call validation function with resolved response data', async() => {
 		return data;
 	});
 
-	var req = Object.create(HttpRequest);
+	const req = Object.create(HttpRequest);
 	req.build({
 		...simpleGetDeletePayload
 	})
 	.validate(validationFunction);
 
 	// Execute
-	var res = await req.get();
+	const res = await req.get();
 
 	// Test
 	expect(rp.get).toHaveBeenCalledWith(req.payload);


### PR DESCRIPTION
- Add support for batched requests through new `BatchRequest` object
- Create `BatchRequest`s via the `HttpRequest.batch('some_id')` function
- Combine `HttpRequestExecutor` into `HttpRequest`, separate core object building functionality out into a new `HttpRequestBase` object which is on the prototype chain of both `HttpRequest` and `BatchRequest` so that both can share the same interface
- Change test filenames from .test.js to .spec.js
- Add batch request documentation to README
- Add tests for `BatchRequest`

/cc @trevorrecker 