### PR TITLE
Update to ES Modules, remove request dependency and transition to axios, bugfixes for BatchRequests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: cimg/node:16.13.0
 
     working_directory: ~/repo
 
@@ -22,5 +22,5 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -5,40 +5,41 @@
 
 ### Fluent HTTP request executor for Node applications
 
-HttpRequest is a simple Node HTTP client which implements a [fluid interface](https://en.wikipedia.org/wiki/Fluent_interface) to build and send requests. HttpRequest Objects can be built in a number of different ways, including building and sending them immediately or building them over time and sending after all required pieces have been assembled. HttpRequest encourages thinking of requests as Objects rather than actions: an HttpRequest Object holds its payload internally and can send it at any time — immediately or later on. This is a subtle but important distinction from other HTTP clients which expect a completed payload to be passed into a function call for instant execution.
+HttpRequest is a simple Node HTTP client which implements a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) to build and send requests. HttpRequest objects can be built in a number of different ways, including building and sending them immediately or building them over time and sending after all required pieces have been assembled. HttpRequest encourages thinking of requests as objects rather than actions: an HttpRequest object holds its payload internally and can send it at any time — immediately or later on. This is a subtle but important distinction from other HTTP clients which expect a completed payload to be passed into a function call for instant execution.
 
-HttpRequest Objects can be reused to fire the same request multiple time in a row, or to tweak a few request fields for different requests while persisting common values. They can be passed between functions and triggered by any of them without needing a particular function to deal with execution details. The fluid interface allows building HttpRequests with a chained syntax that is clear and concise.
+HttpRequest objects can be reused to fire the same request multiple time in a row, or to tweak a few request fields for different requests while persisting common values. They can be passed between functions and triggered by any of them without needing a particular function to deal with execution details. The fluid interface allows building HttpRequests with a chained syntax that is clear and concise.
 
-HttpRequest also supports batching requests via the `HttpRequest.batch()` function. This function will return a new BatchRequest object, which is slightly different than a standard HttpRequest in functionality. BatchRequest objects are explained in further detail below.
+HttpRequest also supports batching requests via the `HttpRequest.batch()` function, which will return a new BatchRequest object. BatchRequests are slightly different than standard HttpRequest objects, and are explained in detail below.
 
 ## Usage
 
 Install HttpRequest from npm:
 
 ```
-$ npm install @unplgtc/http-request --save
+$ npm i @unplgtc/http-request
 ```
 
-Import HttpRequest into your Node project:
+Import HttpRequest into your Node project (only ES Module import is support as of version 4.0.0):
 
 ```js
-const HttpRequest = require('@unplgtc/http-request');
+import HttpRequest from '@unplgtc/http-request';
 ```
 
-Spawn new HttpRequest Objects either with `Object.create(HttpRequest)` or with `HttpRequest.create()`:
+Spawn new HttpRequest objects either with `Object.create(HttpRequest)` or with `HttpRequest.create()`:
 
 ```js
-var req = Object.create(HttpRequest);
+const req = Object.create(HttpRequest);
 
-var anotherReq = HttpRequest.create();
+const anotherReq = HttpRequest.create();
 ```
 
 `HttpRequest.create()` is just a shortcut for `Object.create(HttpRequest)`, so they can be used entirely interchangeably based on your code style preferences.
 
-HttpRequests currently support seven **Native Fields**: `url`, `headers`, `body`, `json`, `qs`, `timeout`, and `resolveWithFullResponse`. All additional fields supported by the [request package](https://www.npmjs.com/package/request) are still supported as **Option Fields**. All fields, both optional and native, can be set with a single payload using the `build()` function.
+HttpRequests currently support seven **Native Fields**: `url`, `headers`, `body` (alias `data`), `responseType` (alias `json` as a shortcut for `responseType: 'json'`), `params` (alias `qs`), `timeout`, and `resolveWithFullResponse`. All additional fields supported by the [axios package](https://www.npmjs.com/package/axios) are still supported as **Option Fields**. All fields, both optional and native, can be set with a single payload using the `build()` function.
 
 ```js
-var req = HttpRequest.create();
+const req = HttpRequest.create();
+
 req.build({
 	url: 'some_url',
 	headers: {
@@ -48,26 +49,26 @@ req.build({
 		someKey: 'some_value'
 	},
 	timeout: 5000,
-	json: true
+	responseType: 'json'
 });
 ```
 
 ### Native Fields
 
-Each native field can be set individually using its eponymous setter, and can be referenced from the HttpRequest object's `payload` field. Boolean fields (`json` and `resolveWithFullResponse`) can be set to true by not passing any value to the setter (e.g., `.json()` is equivalent to `.json(true)`). An extra `header()` setter exists to set individual values in the `headers` field.
+Each native field can be set individually using its eponymous setter, and can be referenced from the HttpRequest object's `payload` field. Boolean fields (`resolveWithFullResponse`) can be set to true by not passing any value to the setter (e.g., `.resolveWithFullResponse()` is equivalent to `.resolveWithFullResponse(true)`). An extra `header()` setter exists to set individual values in the `headers` field.
 
 | Field Name                | Setter                         |
 | ------------------------- | ------------------------------ |
 | `url`                     | `url()`                        |
 | `headers`                 | `headers()`                    |
-| `body`                    | `body()`                       |
-| `json`                    | `json()`                       |
-| `qs`                      | `qs()`                         |
+| `body`                    | `body()` or `data()`           |
+| `responseType`            | `responseType()` or `json()`   |
+| `params`                  | `params()` or `qs()`           |
 | `timeout`                 | `timeout()`                    |
 | `resolveWithFullResponse` | `resolveWithFullResponse()`    |
 
 ```js
-var req = HttpRequest.create()
+const req = HttpRequest.create()
 	.url('some_url')
 	.headers({
 		Authorization: 'some_token'
@@ -78,7 +79,7 @@ var req = HttpRequest.create()
 	})
 	.timeout(3000)
 	.resolveWithFullResponse()
-	.json();
+	.json(); // Or `.responseType('json');`
 ```
 
 ### Option Fields
@@ -86,24 +87,24 @@ var req = HttpRequest.create()
 All option fields can be set using the `options()` or `option()` functions and referenced as children of the `options` field of the HttpRequest object's `payload`.
 
 ```js
-var req = HttpRequest.create();
-req.build({
-	url: 'some_url',
-	optionalField: 'data'
-});
+const req = HttpRequest.create()
+	.build({
+		url: 'some_url',
+		optionalField: 'data'
+	});
 
-// get the optional field's data
-var optionalData = req.payload.options.optionalField;
+// Get the optional field's data
+const optionalData = req.payload.options.optionalField;
 
-// set an optional field to a new value
+// Set an optional field to a new value
 req.option('optionalField', 'other_data');
 ```
 
-#### options(options)
+#### `.options(options)`
 
 A function that sets all options to the specified payload. Any existing option fields will be overwritten.
 
-#### option(key, value)
+#### `.option(key, value)`
 
 The first argument is the name of the option to update. The second argument is the value to store for the specified option.
 
@@ -114,39 +115,41 @@ The option field with the specified key will be updated to the provided value.
 HttpRequest supports the passage of a validation function (a "validator") which will be executed on a successfully returned response. Validators are passed in via the `.validate()` function. When an HttpRequest with a validator is executed, it will automatically `await` the response and (if successful) pass it to the validator. Note that the validator will then be returned by HttpRequest, so validator functions will need to return the data after completion if it is required for further logic. If a response is unsuccessful then the promise will be rejected as usual and the validator will not be called.
 
 ```js
-var res = HttpRequest.create()
-    .url('some_url')
-    .header('Authorization', 'some_token')
-    .json(true)
-    .validate(data => {
-        if (data.verificationToken === 'your_verification_token') {
-        	throw new Error('Invalid Verification Token in Response');
-        }
-        return data;
-    })
-    .get()
+const res = HttpRequest.create()
+	.url('some_url')
+	.header('Authorization', 'some_token')
+	.json()
+	.validate(data => {
+		if (data.verificationToken !== 'your_verification_token') {
+			throw new Error('Invalid Verification Token in Response');
+		}
+		return data;
+	})
+	.get();
 ```
 
-HttpRequest is unopinionated about your validation functions. Internally it calls `return validator(await rp[method](payload))` instead of its normal `return rp[method](payload)`. If the call to `rp` (`request-promise-native`) fails then that failure is returned as a rejected promise just like in the normal case. If it succeeds then you get to validate your returned data in any way you please. A common use case for this pattern is to verify objects against a JSON schema through a library like [`ajv`](https://github.com/epoberezkin/ajv). This way you can know immediately that a successfully returned result from HttpRequest is a valid object with expected parameters, which can significantly reduce the amount of saftey checks that you may otherwise need scattered throughout your code.
+HttpRequest is unopinionated about your validation functions. Internally it calls (essentially) `return validator(await axios(payload))` instead of its normal `return axios(payload)`. If the call to `axios` fails then that failure is returned as a rejected promise just like in the normal case. If it succeeds then you get to validate your returned data in any way you please.
+
+A common use case for this pattern is to verify objects against a JSON schema through a library like [`ajv`](https://github.com/epoberezkin/ajv). This way you can know immediately that a successfully returned result from HttpRequest is a valid object with expected parameters, which can significantly reduce the amount of safety checks that you may otherwise need scattered throughout your code.
 
 ```js
-const Ajv = require('ajv'),
-      UserSchema = require('./path/to/some/UserSchema'),
-      HttpRequest = require('@unplgtc/HttpRequest');
+import Ajv from 'ajv';
+import UserSchema from './path/to/some/UserSchema';
+import HttpRequest from '@unplgtc/HttpRequest';
 
 const ajv = new Ajv();
 
-var res = HttpRequest.create()
-    .url('some_url')
-    .header('Authorization', 'some_token')
-    .json(true)
-    .validate(data => {
+const res = HttpRequest.create()
+	.url('some_url')
+	.header('Authorization', 'some_token')
+	.json()
+	.validate(data => {
 		if (!ajv.validate(UserSchema, data)) {
 			throw new Error('Invalid User object returned in Response');
 		}
-        return data;
-    })
-    .get()
+		return data;
+	})
+	.get();
 ```
 
 ---
@@ -154,32 +157,31 @@ var res = HttpRequest.create()
 Send a request using the `.get()`, `.post()`, `.put()`, and `.delete()` methods.
 
 ```js
-var res = req.put();
+const res = req.put();
 ```
 
 These can of course be chained along with the other functions to immediately build and send a request.
 
 ```js
-var res = HttpRequest.create()
+const res = HttpRequest.create()
 	.url('some_url')
 	.header('Authorization', 'some_token')
 	.body({ someKey: 'some_value' })
-	.json(true)
 	.post();
 ```
 
-The `build()` function is chainable as well.
+The `build()` function can be chained as well.
 
 ```js
 var res = HttpRequest.create()
-	.build({url: 'some_url', json: true})
+	.build({ url: 'some_url' })
 	.get();
 ```
 
-Finally, if you have an existing HttpRequest Object and want to review its payload, just pull it with the `.payload` getter.
+Finally, if you have an existing HttpRequest object and want to review its payload, just pull it with the `payload` getter.
 
 ```js
-var req = HttpRequest.create()
+const req = HttpRequest.create()
 	.url('some_url');
 
 console.log(req.payload);
@@ -213,18 +215,18 @@ If you don't call `throttle()` on any requests in a batch then all requests will
 
 ```js
 const req1 = HttpRequest.batch('some_id')
-	.build({url: 'some_url', json: true})
+	.build({ url: 'some_url' })
 	.get();
 
 const req2 = HttpRequest.batch('some_id')
-	.build({url: 'some_url', json: true})
+	.build({ url: 'some_other_url' })
 	.get();
 
 const res1 = await req1, // Executed concurrently
       res2 = await req2; // Executed concurrently
 ```
 
-For batched requests the `.get()`, `.post()`, `.put()`, and `.delete()` functions do *not* immediately invoke the request. Instead, those functions simply set the method option for their request. When the batch is executed the specified method will be used for each request. Batch execution occurs automatically 50 milliseconds after the last request is added. If you don't want to or can't easily determine which request is the last one, HttpRequest will do it for you based on no more requests being added. Each time a request is added the 50 millisecond clock resets.
+For batched requests the `.get()`, `.post()`, `.put()`, and `.delete()` functions do *not* immediately invoke the request. Instead, those functions simply set the method option for their request. When the batch is executed, the specified method will be used for each request. Batch execution occurs automatically 50 milliseconds after the last request is added. If you don't want to or can't easily determine which request is the last one, HttpRequest will do it for you based on no more requests being added. Each time a request is added, the 50 millisecond clock resets.
 
 The `stall()` function can be used to set the amount of time before a batch is automatically executed. If 50 milliseconds is too little time or too much time then you can chain a `.stall()` command to raise or lower the value for that batch.
 
@@ -232,11 +234,11 @@ The `stall()` function can be used to set the amount of time before a batch is a
 const req1 = HttpRequest.batch('some_id')
 	.stall(5000)
 	.throttle(1000)
-	.build({url: 'some_url', json: true})
+	.build({ url: 'some_url' })
 	.get();
 
 const req2 = HttpRequest.batch('some_id')
-	.build({url: 'some_url', json: true})
+	.build({ url: 'some_other_url' })
 	.get();
 
 const res1 = await req1, // Will execute after 5 seconds
@@ -263,8 +265,6 @@ Under the hood, `HttpRequest.batch()` returns a `BatchRequest` object rather tha
 
 ## Further Documentation
 
-Please refer to the [`request-promise` documentation](https://www.npmjs.com/package/request-promise) for further specifications such as the response data format and additional optional fields. Everything with the response and options will be the same except the following:
+Please refer to the [`axios` documentation](https://www.npmjs.com/package/axios) for further specifications such as the response data format and additional optional fields. Everything with the response and options will be the same except the following:
 
-- This implementation uses [`request-promise-native`](https://www.npmjs.com/package/request-promise-native), which itself uses native ES6 promises instead of Bluebird promises.
-- Mind that native ES6 promises have fewer features than Bluebird promises do. In particular, the `.finally(...)` method is not available.
-- `request-promise-native` sets `resolveWithFullResponse` to `false` by default, which means successful responses have only their bodies returned in the resolved Promise. Similarly, unsuccessful responses have only their error bodies returned in the rejected Promise. If you need to examine the entire response, including status codes and headers (as you must do when using the [standard `request` package](https://www.npmjs.com/package/request)), then call `.resolveWithFullResponse()` on your `HttpRequest` object before executing it.
+- `HttpRequest` sets `resolveWithFullResponse` to `false` by default, which means successful responses have only their bodies returned in the resolved Promise. Similarly, unsuccessful responses have only their error bodies returned in the rejected Promise. If you need to examine the entire response, including status codes and headers (as you must do when using the [standard `axios` package](https://www.npmjs.com/package/axios)), then call `.resolveWithFullResponse()` on your `HttpRequest` object before executing it.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
-module.exports = {
+export default {
   clearMocks: true,
   coverageDirectory: "test/coverage",
   rootDir: "test",
-  testEnvironment: "node"
+  testEnvironment: "node",
+  transform: {}
 };

--- a/package.json
+++ b/package.json
@@ -2,27 +2,30 @@
   "name": "@unplgtc/http-request",
   "version": "3.0.0",
   "description": "Fluent HTTP request executor for Node applications",
-  "main": "src/HttpRequest.js",
+  "type": "module",
+  "exports": "./src/HttpRequest.js",
+  "engines": {
+    "node": ">=14.13.1 || >=16.0.0"
+  },
   "scripts": {
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/unplgtc/HttpRequest.git"
   },
-  "author": "Alex Guyot <guyot@unapologetic.io> (https://unapologetic.io)",
+  "author": "Alex Guyot <alex@unapologetic.io> (https://unapologetic.io)",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/unplgtc/HttpRequest/issues"
   },
   "homepage": "https://github.com/unplgtc/HttpRequest#readme",
   "devDependencies": {
-    "jest": "^23.4.2"
+    "axios-mock-adapter": "^1.20.0",
+    "jest": "^27.3.1"
   },
   "dependencies": {
-    "@unplgtc/cblogger": "1.0.2",
-    "@unplgtc/standard-error": "1.0.0",
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.5"
+    "@unplgtc/standard-error": "2.0.0",
+    "axios": "^0.24.0"
   }
 }

--- a/src/BatchRequest.js
+++ b/src/BatchRequest.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const HttpRequestBase = require('./HttpRequestBase'),
-      rp = require('request-promise-native'),
-      StandardError = require('@unplgtc/standard-error');
+import HttpRequestBase from './HttpRequestBase.js';
+import axios from 'axios';
+import StandardError from '@unplgtc/standard-error';
 
 let executionTimer;
 
@@ -10,7 +8,7 @@ const BatchRequest = {
 	requests: [], // How do we clean these once they've executed?
 
 	stallMs: 50,
-	
+
 	stall(milliseconds) {
 		this.parent
 		? (this.parent.stallMs = milliseconds)
@@ -20,15 +18,20 @@ const BatchRequest = {
 	},
 
 	throttle(milliseconds) {
+		if (!milliseconds || milliseconds < 50) {
+			milliseconds = 50;
+		}
+
 		this.parent
-		? (this.parent.throttleMs = milliseconds)
-		: (this.throttleMs = milliseconds);
+			? (this.parent.throttleMs = milliseconds)
+			: (this.throttleMs = milliseconds);
 
 		return this;
 	},
 
 	addRequest(cleanup) {
 		const child = this.spawnChild();
+
 		child.result = new Promise((resolve, reject) => {
 			child.resolve = resolve;
 			child.reject = reject;
@@ -64,31 +67,32 @@ const BatchRequest = {
 
 	get(shouldExecute) {
 		return shouldExecute
-		? this.execute('get')
-		: this.executeDelayed('get');
+			? this.execute('get')
+			: this.executeDelayed('get');
 	},
 
 	post(shouldExecute) {
 		return shouldExecute
-		? this.execute('post')
-		: this.executeDelayed('post');
+			? this.execute('post')
+			: this.executeDelayed('post');
 	},
 
 	put(shouldExecute) {
 		return shouldExecute
-		? this.execute('put')
-		: this.executeDelayed('put');
+			? this.execute('put')
+			: this.executeDelayed('put');
 	},
 
 	delete(shouldExecute) {
 		return shouldExecute
-		? this.execute('delete')
-		: this.executeDelayed('delete');
+			? this.execute('delete')
+			: this.executeDelayed('delete');
 	},
 
 	execute(method) {
-		if (this.parent) {
-			this.method = method;
+		this.method = method;
+
+		if (this.parent && !this.parent.executing) {
 			this.parent.clearExecutionTimer();
 			this.parent.executeAll(this.parent.requests)();
 		}
@@ -97,8 +101,9 @@ const BatchRequest = {
 	},
 
 	executeDelayed(method) {
-		if (this.parent) {
-			this.method = method;
+		this.method = method;
+
+		if (this.parent && !this.parent.executing) {
 			this.parent.setExecutionTimer();
 		}
 
@@ -115,27 +120,31 @@ const BatchRequest = {
 
 	executeAll(requests) {
 		return async () => {
-			this.throttle && this.throttle < 10
-			? await this.executeConcurrently(requests)
-			: await this.executeThrottled(requests);
+			this.executing = true;
+
+			this.throttleMs
+				? await this.executeThrottled(requests)
+				: await this.executeConcurrently(requests);
 
 			this.cleanup();
+
+			this.executing = false;
 		}
 	},
 
 	executeConcurrently(requests) {
-		return Promise.all(
+		return Promise.allSettled(
 			requests.map(request => this.executeOne(request))
 		);
 	},
 
 	executeThrottled: async function(requests) {
 		for (const request of requests) {
-			await (this.throttledRequest(request));
+			await (this.throttleRequest(request));
 		}
 	},
 
-	throttledRequest(request) {
+	throttleRequest(request) {
 		return new Promise((resolve) => {
 			return setTimeout(() => {
 				resolve(this.executeOne(request));
@@ -144,22 +153,43 @@ const BatchRequest = {
 	},
 
 	executeOne: async function(request) {
-		if (!Object.keys(request.payload).length || !request.payload.url || !request.method) {
+		if (!request?.payload?.url || !request.method) {
 			return request.reject(StandardError.BatchRequest_400());
 		}
-		return request.resolve(
-			request.validator
-			? request.validator(await rp[request.method](request.payload))
-			: rp[request.method](request.payload)
-		);
+
+		if (request.payload.resolveWithFullResponse) {
+			delete request.payload.resolveWithFullResponse;
+
+			return request.resolve(
+				request.validator
+					? request.validator(await axios({ ...request.payload, method: request.method }))
+					: axios({ ...request.payload, method: request.method })
+			);
+
+		} else {
+			let resErr;
+			const res = await axios({ ...request.payload, method: request.method })
+				.catch(err => (resErr = err));
+
+			if (resErr) {
+				return request.reject(resErr);
+
+			} else {
+				return request.resolve(
+					this.validator
+						? request.validator(res?.data)
+						: res?.data
+				);
+			}
+		}
 	}
 }
 
 StandardError.add([
-	{code: 'BatchRequest_400', domain: 'HttpRequest', title: 'Bad Request', message: 'Cannot execute batched HttpRequest with empty payload, url, or method'}
+	{ code: 'BatchRequest_400', domain: 'HttpRequest', title: 'Bad Request', message: 'HTTP request missing url or method' }
 ]);
 
 // Delegate BatchRequest -> HttpRequestBase
 Object.setPrototypeOf(BatchRequest, HttpRequestBase);
 
-module.exports = BatchRequest;
+export default BatchRequest;

--- a/src/HttpRequestBase.js
+++ b/src/HttpRequestBase.js
@@ -1,31 +1,30 @@
-'use strict';
-
 const HttpRequestBase = {
 	get payload() {
 		return {
-			...(this._options != null && this._options),
-			...(this._url != null     && { url: this._url         }),
-			...(this._headers != null && { headers: this._headers }),
-			...(this._body != null    && { body: this._body       }),
-			...(this._json != null    && { json: this._json       }),
-			...(this._qs != null      && { qs: this._qs           }),
-			...(this._timeout != null && { timeout: this._timeout }),
+			...(this._options != null      && this._options),
+			...(this._url != null          && { url: this._url                   }),
+			...(this._headers != null      && { headers: this._headers           }),
+			...(this._body != null         && { data: this._body                 }),
+			...(this._responseType != null && { responseType: this._responseType }),
+			...(this._params != null       && { params: this._params             }),
+			...(this._timeout != null      && { timeout: this._timeout           }),
 			resolveWithFullResponse: (this._resolveWithFullResponse != null ?
-				this._resolveWithFullResponse : false
-			)
+				this._resolveWithFullResponse : false)
 		}
 	},
 
-	build(data = {}) {
-		const {url, headers, body, json, qs, resolveWithFullResponse, timeout, ...options} = data;
+	build(payload = {}) {
+		const { url, headers, body, data, json, responseType, params, qs, timeout, ...options } = payload;
 
-		url != null     && (this._url = url);
-		headers != null && (this._headers = headers);
-		body != null    && (this._body = body);
-		json != null    && (this._json = json);
-		qs != null      && (this._qs = qs);
-		timeout != null && (this._timeout = timeout);
-		resolveWithFullResponse != null && (this._resolveWithFullResponse = resolveWithFullResponse);
+		url != null          && (this._url = url);
+		headers != null      && (this._headers = headers);
+		body != null         && (this._body = body);
+		data != null         && (this._body = data); // `data` overrides `body`
+		json == true         && (this._responseType = 'json');
+		responseType != null && (this._responseType = responseType); // `responseType` overrides `json`
+		qs != null           && (this._params = qs);
+		params != null       && (this._params = params); // `params` overrides `qs`
+		timeout != null      && (this._timeout = timeout);
 
 		Object.keys(options).length > 0 && (this._options = options);
 
@@ -55,9 +54,33 @@ const HttpRequestBase = {
 		return this;
 	},
 
-	json(json) {
-		// If nothing is passed to this function, set _json to true
-		this._json = json != null ? json : true;
+	data(data) {
+		this._body = data;
+		return this;
+	},
+
+	json() {
+		this._responseType = 'json';
+		return this;
+	},
+
+	responseType() {
+		this._responseType = responseType;
+		return this;
+	},
+
+	qs(qs) {
+		this._params = qs;
+		return this;
+	},
+
+	params(params) {
+		this._params = params;
+		return this;
+	},
+
+	timeout(timeout) {
+		this._timeout = timeout;
 		return this;
 	},
 
@@ -67,20 +90,10 @@ const HttpRequestBase = {
 		return this;
 	},
 
-	qs(qs) {
-		this._qs = qs;
-		return this;
-	},
-
-	timeout(timeout) {
-		this._timeout = timeout;
-		return this;
-	},
-
 	option(key, value) {
 		return this.build({
-			...(this._options != null && this._options), 
-			[key]: value 
+			...(this._options != null && this._options),
+			[key]: value
 		});
 	},
 
@@ -101,4 +114,4 @@ const HttpRequestBase = {
 	}
 }
 
-module.exports = HttpRequestBase;
+export default HttpRequestBase;


### PR DESCRIPTION
This update drops support for CommonJS in favor of ES Modules.

HttpRequest now uses `axios`, and supports all associated Axios options. However, I brought the `resolveWithFullResponse` behavior over from `request-promise-native`. Resolving with only the response body continues to be the default for HttpRequest even though the Axios default is to resolve with the full Axios response object. If you want the full response object, just call `.resolveWithFullResponse()` on your HttpRequest like you have always done previously.

Fixed some nasty bugs in BatchRequest. Mainly, one where passing the immediate execution parameter on multiple batched requests in a row would cause the earlier requests to be executed multiple times. This should no longer be possible, and now an error is thrown if you try to immediately execute the same batch ID more than once (this simply doesn't make sense — if you want immediate execution then stop batching your request and just use HttpRequest).

Also improved some edge case error handling bugs in both HttpRequest and BatchRequest.

@trevorrecker In case you're interested in the changes 😁 