### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/http-request",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Fluent HTTP request executor for Node applications",
   "type": "module",
   "exports": "./src/HttpRequest.js",


### PR DESCRIPTION
Changelog:
- Upgrade to ES Modules imports
- Drop support for CommonJS imports
- Switch from deprecated `request` package to `axios`
- `.responseType('[type]')` function now used to set response type (defaults to 'json')
- `.json()` function no longer takes arguments, is now an alias for `.responseType('json')`
- Bug fixes for BatchRequest
- Improved error handling